### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,3 +1195,4 @@ A curated list of awesome Shell frameworks, libraries and software.
 * [mxmnk/shell](https://github.com/mxmnk/shell) - shell
 * [reale/bashlets](https://github.com/reale/bashlets) - An experiment in extending the command-line interface.
 * [BeginMan/myshell](https://github.com/BeginMan/myshell) - 写的常用Shell小工具，运维小脚本等
+* [Ducksss/codex-profiles](https://github.com/Ducksss/codex-profiles) - Switch Codex CLI and Desktop accounts with isolated `CODEX_HOME` profile directories.


### PR DESCRIPTION
## Summary
- Adds `Ducksss/codex-profiles`, a small CLI for switching Codex CLI/Desktop accounts through isolated `CODEX_HOME` profile directories
- Places the link in the general shell tooling list with a concise description

## Validation
- `git diff --check`

This is a shell-facing developer utility, so the listing keeps the description focused on command-line profile switching.